### PR TITLE
[Enhancement] Add InputTextField Min Height

### DIFF
--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/input/InputTextField.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/input/InputTextField.kt
@@ -1,6 +1,5 @@
 package io.github.hellocuriosity.compose.ui.components.input
 
-import android.R
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -46,6 +45,7 @@ fun InputTextField(
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
     maxLength: Int? = null,
+    minHeight: Dp = 0.dp,
     hasCounter: Boolean = false,
     boarderWidth: Dp = 0.dp,
     colors: InputTextFieldColors = InputTextFieldDefaults.colors(),
@@ -70,6 +70,7 @@ fun InputTextField(
     TextField(
         modifier = Modifier
             .fillMaxWidth()
+            .defaultMinSize(minHeight = minHeight)
             .testTag(INPUT_TEXT_FIELD_VALUE_TEST_TAG),
         value = text,
         onValueChange = {
@@ -123,9 +124,9 @@ const val INPUT_TEXT_FIELD_COUNTER_TEST_TAG = "INPUT_TEXT_FIELD_COUNTER_TEST_TAG
 fun InputTextFieldPreview() {
     InputTextField(
         modifier = Modifier.defaultMinSize(minHeight = 100.dp),
-        placeholder = R.string.copy,
+        placeholder = android.R.string.copy,
         hasCounter = true,
         maxLength = 30,
-        value = { }
+        value = { },
     )
 }

--- a/curiosity/src/test/java/io/github/hellocuriosity/compose/ui/components/input/InputTextFieldTest.kt
+++ b/curiosity/src/test/java/io/github/hellocuriosity/compose/ui/components/input/InputTextFieldTest.kt
@@ -73,6 +73,7 @@ class InputTextFieldTest : ComposeTest() {
                 singleLine = false,
                 maxLines = 5,
                 maxLength = 10,
+                minHeight = 15.dp,
                 hasCounter = false,
                 boarderWidth = 10.dp,
                 colors = InputTextFieldDefaults.colors(


### PR DESCRIPTION
## Description

This adds a `minHeight` configuration to the `InputTextField` component.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
