### PR TITLE
chore: remove redundant compose Exclude annotation

### DIFF
--- a/app/src/main/java/com/hello/curiosity/Exclude.kt
+++ b/app/src/main/java/com/hello/curiosity/Exclude.kt
@@ -1,4 +1,0 @@
-package com.hello.curiosity
-
-@Suppress("EmptyDefaultConstructor")
-internal annotation class Exclude

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/SettingsScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/SettingsScene.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import com.hello.curiosity.Exclude
 import com.hello.curiosity.R
 import com.hello.curiosity.ui.theme.AppTheme.lightCyan
 import com.hello.curiosity.ui.theme.AppTheme.metallicSeaweed
@@ -95,7 +94,6 @@ fun SettingsScene() {
     }
 }
 
-@Exclude
 @Preview
 @Composable
 internal fun SettingsScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorScene.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import com.hello.curiosity.Exclude
 
 @Composable
 @Suppress("MagicNumber", "LongMethod")
@@ -75,7 +74,6 @@ internal fun ColorScene() {
     }
 }
 
-@Exclude
 @Preview
 @Composable
 internal fun ColorScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorView.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorView.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hello.curiosity.Exclude
 
 @Composable
 internal fun ColorView(presentation: ColorPresentation) =
@@ -32,7 +31,6 @@ internal fun ColorView(presentation: ColorPresentation) =
         Text(text = presentation.title)
     }
 
-@Exclude
 @Preview
 @Composable
 internal fun ColorViewPreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/ButtonScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/ButtonScene.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hello.curiosity.Exclude
 import com.hello.curiosity.R
 import io.github.hellocuriosity.compose.ui.components.buttons.IconButton
 import io.github.hellocuriosity.compose.ui.components.buttons.TextButton
@@ -89,7 +88,6 @@ fun ButtonScene() {
     }
 }
 
-@Exclude
 @Preview
 @Composable
 fun ButtonScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/ComponentScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/ComponentScene.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import com.hello.curiosity.Exclude
 import com.hello.curiosity.ui.scenes.Scenes
 import io.github.hellocuriosity.compose.ui.components.buttons.TextIconButton
 
@@ -52,7 +51,6 @@ fun ComponentScene(navController: NavHostController) {
     }
 }
 
-@Exclude
 @Preview
 @Composable
 fun ComponentScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/InputScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/InputScene.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hello.curiosity.Exclude
 import com.hello.curiosity.R
 import com.hello.curiosity.ui.theme.inputTextFieldColors
 import io.github.hellocuriosity.compose.ui.components.input.InputTextField
@@ -73,7 +72,6 @@ fun InputScene() {
 
 const val INPUT_SCENE_VIEW_TEST_TAG = "INPUT_SCENE_VIEW_TEST_TAG"
 
-@Exclude
 @Preview
 @Composable
 fun InputScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/TextScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/TextScene.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hello.curiosity.Exclude
 import io.github.hellocuriosity.compose.ui.components.text.ContentLarge
 import io.github.hellocuriosity.compose.ui.components.text.ContentMedium
 import io.github.hellocuriosity.compose.ui.components.text.LabelLarge
@@ -68,7 +67,6 @@ fun TextScene() {
     }
 }
 
-@Exclude
 @Preview
 @Composable
 fun TextScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/ToggleScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/ToggleScene.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hello.curiosity.Exclude
 import com.hello.curiosity.R
 import com.hello.curiosity.ui.theme.checkColors
 import com.hello.curiosity.ui.theme.dropDownMenuColors
@@ -67,7 +66,6 @@ fun ToggleScene() {
     }
 }
 
-@Exclude
 @Preview
 @Composable
 fun ToggleScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/type/TypographyScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/type/TypographyScene.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hello.curiosity.Exclude
 
 @Composable
 @Suppress("LongMethod")
@@ -86,7 +85,6 @@ fun TypographyScene() {
     }
 }
 
-@Exclude
 @Preview
 @Composable
 fun TypographyScenePreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/Exclude.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/Exclude.kt
@@ -1,4 +1,0 @@
-package io.github.hellocuriosity.compose.ui
-
-@Suppress("EmptyDefaultConstructor")
-internal annotation class Exclude

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/input/InputTextField.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/input/InputTextField.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.github.hellocuriosity.compose.ui.Exclude
 import io.github.hellocuriosity.compose.ui.components.text.LabelSmall
 import io.github.hellocuriosity.compose.ui.components.text.LabelTiny
 
@@ -122,7 +121,6 @@ const val INPUT_TEXT_FIELD_CONTAINER_TEST_TAG = "INPUT_TEXT_FIELD_CONTAINER_TEST
 const val INPUT_TEXT_FIELD_VALUE_TEST_TAG = "INPUT_TEXT_FIELD_VALUE_TEST_TAG"
 const val INPUT_TEXT_FIELD_COUNTER_TEST_TAG = "INPUT_TEXT_FIELD_COUNTER_TEST_TAG"
 
-@Exclude
 @Preview
 @Composable
 fun InputTextFieldPreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/selector/DropDownMenu.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/selector/DropDownMenu.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.hellocuriosity.compose.R
-import io.github.hellocuriosity.compose.ui.Exclude
 import io.github.hellocuriosity.compose.ui.components.text.LabelSmall
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -105,7 +104,6 @@ const val DROP_DOWN_MENU_CONTAINER_TEST_TAG = "DROP_DOWN_MENU_CONTAINER_TEST_TAG
 const val DROP_DOWN_MENU_ICN_TEST_TAG = "DROP_DOWN_MENU_ICN_TEST_TAG"
 const val DROP_DOWN_MENU_LIST_TEST_TAG = "DROP_DOWN_MENU_LIST_TEST_TAG"
 
-@Exclude
 @Preview
 @Composable
 fun DropDownMenuPreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/ContentLarge.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/ContentLarge.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @Composable
 fun ContentLarge(
@@ -51,7 +50,6 @@ fun ContentLarge(
     maxLines = maxLines,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun ContentLargePreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/ContentMedium.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/ContentMedium.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @Composable
 fun ContentMedium(
@@ -51,7 +50,6 @@ fun ContentMedium(
     maxLines = maxLines,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun ContentMediumPreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelLarge.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelLarge.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @Composable
 fun LabelLarge(
@@ -51,7 +50,6 @@ fun LabelLarge(
     maxLines = maxLines,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun LabelLargePreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelMedium.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelMedium.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @Composable
 fun LabelMedium(
@@ -51,7 +50,6 @@ fun LabelMedium(
     maxLines = maxLines,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun LabelMediumPreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelSmall.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelSmall.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @Composable
 fun LabelSmall(
@@ -51,7 +50,6 @@ fun LabelSmall(
     maxLines = maxLines,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun LabelSmallPreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelTiny.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/text/LabelTiny.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @Composable
 fun LabelTiny(
@@ -51,7 +50,6 @@ fun LabelTiny(
     maxLines = maxLines,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun LabelTinyPreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/toggle/CheckBox.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/toggle/CheckBox.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.hellocuriosity.compose.R
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -66,7 +65,6 @@ fun CheckBox(
     }
 }
 
-@Exclude
 @Preview
 @Composable
 fun CheckboxPreview() {

--- a/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/toggle/Toggle.kt
+++ b/curiosity/src/main/java/io/github/hellocuriosity/compose/ui/components/toggle/Toggle.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import io.github.hellocuriosity.compose.ui.Exclude
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -64,7 +63,6 @@ fun Toggle(
 const val TOGGLE_CONTAINER_TEST_TAG = "TOGGLE_CONTAINER_TEST_TAG"
 const val TOGGLE_BTN_TEST_TAG = "TOGGLE_BTN_TEST_TAG"
 
-@Exclude
 @Preview
 @Composable
 fun TogglePreview() {

--- a/settings/src/main/java/io/github/hellocuriosity/compose/settings/Exclude.kt
+++ b/settings/src/main/java/io/github/hellocuriosity/compose/settings/Exclude.kt
@@ -1,4 +1,0 @@
-package io.github.hellocuriosity.compose.settings
-
-@Suppress("EmptyDefaultConstructor")
-internal annotation class Exclude

--- a/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemAction.kt
+++ b/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemAction.kt
@@ -53,7 +53,6 @@ fun ItemAction(
     )
 }
 
-@Exclude
 @Preview
 @Composable
 internal fun ItemActionPreview() {

--- a/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemDivider.kt
+++ b/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemDivider.kt
@@ -24,7 +24,6 @@ fun ItemDivider(
     thickness = thickness,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun ItemDividerPreview() {

--- a/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemDropDown.kt
+++ b/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemDropDown.kt
@@ -53,7 +53,6 @@ fun ItemDropDown(
 
 const val ITEM_DROP_DOWN_CONTAINER_TEST_TAG = "ITEM_DROP_DOWN_CONTAINER_TEST_TAG"
 
-@Exclude
 @Preview
 @Composable
 internal fun ItemDropDownPreview() {

--- a/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemInfo.kt
+++ b/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemInfo.kt
@@ -46,7 +46,6 @@ fun ItemInfo(
     }
 }
 
-@Exclude
 @Preview
 @Composable
 internal fun ItemInfoPreview() {

--- a/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemSection.kt
+++ b/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemSection.kt
@@ -30,7 +30,6 @@ fun ItemSection(
     style = style,
 )
 
-@Exclude
 @Preview
 @Composable
 internal fun ItemSectionPreview() {

--- a/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemToggle.kt
+++ b/settings/src/main/java/io/github/hellocuriosity/compose/settings/ItemToggle.kt
@@ -51,7 +51,6 @@ fun ItemToggle(
 
 const val ITEM_TOGGLE_TEST_TAG = "ITEM_TOGGLE_TEST_TAG"
 
-@Exclude
 @Preview
 @Composable
 internal fun ItemTogglePreview() {


### PR DESCRIPTION
## Summary
- Removes the custom `@Exclude` annotation (and its 3 declaration files) used to mark `@Preview @Composable` previews so kover would skip them.
- The annotation was never wired into the kover excludes filter — the live `kover { reports { filters { excludes { ... } } } }` block in `build.gradle.kts` only references `*BuildConfig` and `*Preview`. Confirmed by inspecting per-module `reportDebug.xml` on `main`: previews already appear there, so removing `@Exclude` is purely a noop cleanup.
- Underlying kover bug ([Kotlin/kotlinx-kover#270](https://github.com/Kotlin/kotlinx-kover/issues/270)) was closed as not-planned, but `annotatedBy("*Preview")` is the supported path in current kover (0.8.3).

Closes #67