### PR TITLE
chore: consolidate gradle config and publishing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,27 +1,23 @@
 import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
-    id("com.github.triplet.play") version "3.13.0"
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.play.publisher)
 }
 
 android {
     namespace = "com.hello.curiosity"
-    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.hello.curiosity.design"
-        minSdk = 23
         targetSdk = 35
 
         versionCode = System.getenv("GITHUB_RUN_NUMBER")?.toInt() ?: 1
         versionName = System.getenv("VERSION") ?: "local"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -47,7 +43,7 @@ android {
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -63,94 +59,44 @@ android {
         artifactDir.set(file("build/outputs/bundle/release"))
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    buildFeatures {
-        compose = true
-    }
-
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-            isReturnDefaultValues = true
-        }
-    }
 }
 
 dependencies {
-    // Android
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation(libs.androidx.core.ktx)
 
-    // Compose
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.compose.material:material:1.11.0")
-    implementation("androidx.compose.material:material-icons-extended:1.7.8")
-    implementation("androidx.navigation:navigation-compose:2.9.8")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.11.0")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.11.0")
-    implementation("androidx.compose.ui:ui:1.11.0")
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
-    // Curiosity
     implementation(project(":curiosity"))
     implementation(project(":navigation"))
     implementation(project(":settings"))
 
-    // Leak
-    debugImplementation("com.squareup.leakcanary:leakcanary-android:2.14")
+    debugImplementation(libs.leakcanary.android)
 
-    // Testing
-    testImplementation("junit:junit:4.13.2")
-
-    // Curiosity testing utils
+    testImplementation(libs.junit)
     testImplementation(project(":test-compose-utils"))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.androidx.navigation.testing)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-    // Compose
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.11.0")
-    testImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
-    testImplementation("androidx.navigation:navigation-testing:2.9.8")
-
-    // Robolectric
-    testImplementation("org.robolectric:robolectric:4.16.1") {
-        exclude(module = "classworlds")
-        exclude(module = "commons-logging")
-        exclude(module = "httpclient")
-        exclude(module = "maven-artifact")
-        exclude(module = "maven-artifact-manager")
-        exclude(module = "maven-error-diagnostics")
-        exclude(module = "maven-model")
-        exclude(module = "maven-project")
-        exclude(module = "maven-settings")
-        exclude(module = "plexus-container-default")
-        exclude(module = "plexus-interpolation")
-        exclude(module = "plexus-utils")
-        exclude(module = "wagon-file")
-        exclude(module = "wagon-http-lightweight")
-        exclude(module = "wagon-provider-api")
-        exclude(module = "auto-service")
-    }
-
-    // Android Testing
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
-    androidTestImplementation("androidx.test.ext:junit:1.3.0")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 }
 
-// Kover
+extra["robolectricConfiguration"] = "testImplementation"
+apply(from = "$rootDir/gradle/robolectric.gradle.kts")
+
 dependencies {
     kover(project(":curiosity"))
     kover(project(":navigation"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,22 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.LibraryExtension
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-
-}// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 plugins {
-    id("com.android.application") version "8.13.2" apply false
-    id("com.android.library") version "8.13.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.21" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 
-    id("io.gitlab.arturbosch.detekt") version "1.23.8"
-    id("org.jmailen.kotlinter") version "5.4.2"
-    id("org.jetbrains.kotlinx.kover") version "0.9.8"
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlinter)
+    alias(libs.plugins.kover)
 }
 
 allprojects {
@@ -42,6 +44,71 @@ allprojects {
     }
 }
 
+fun CommonExtension<*, *, *, *, *, *>.configureAndroidCommon() {
+    compileSdk = 35
+    defaultConfig {
+        minSdk = 23
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    buildFeatures {
+        compose = true
+    }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
+}
+
+subprojects {
+    plugins.withId("com.android.application") {
+        extensions.configure<ApplicationExtension>("android") {
+            configureAndroidCommon()
+        }
+    }
+
+    plugins.withId("com.android.library") {
+        extensions.configure<LibraryExtension>("android") {
+            configureAndroidCommon()
+            defaultConfig {
+                targetSdk = 35
+            }
+            buildTypes {
+                release {
+                    isMinifyEnabled = false
+                }
+            }
+            publishing {
+                singleVariant("release") {
+                    withSourcesJar()
+                    withJavadocJar()
+                }
+            }
+        }
+    }
+
+    plugins.withId("org.jetbrains.kotlin.android") {
+        extensions.configure<KotlinAndroidProjectExtension>("kotlin") {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_17)
+            }
+        }
+    }
+
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        extensions.configure<KotlinJvmProjectExtension>("kotlin") {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_17)
+            }
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }
@@ -52,7 +119,6 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-// Kover
 dependencies {
     kover(project(":app"))
     kover(project(":slack-feedback"))

--- a/curiosity/build.gradle.kts
+++ b/curiosity/build.gradle.kts
@@ -1,171 +1,49 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
 
-    // Publishing
-    id("maven-publish")
+    `maven-publish`
     signing
 }
 
 android {
     namespace = "io.github.hellocuriosity.compose"
-    compileSdk = 35
-    buildToolsVersion = "34.0.0"
 
     defaultConfig {
-        minSdk = 23
-        targetSdk = 34
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    buildFeatures {
-        compose = true
-    }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-            isReturnDefaultValues = true
-        }
     }
 }
 
 dependencies {
-    // Android
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation(libs.androidx.core.ktx)
 
-    // Compose
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.compose.material:material:1.11.0")
-    implementation("androidx.compose.material:material-icons-extended:1.7.8")
-    implementation("androidx.navigation:navigation-compose:2.9.8")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.11.0")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.11.0")
-    implementation("androidx.compose.ui:ui:1.11.0")
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
-    // It is a known bug: https://issuetracker.google.com/issues/227767363
-    //
-    // Google is currently working on a fix but there is already a workaround:
-    // add these dependencies to every module where you use the Compose preview:
-    debugApi("androidx.customview:customview:1.2.0")
-    debugApi("androidx.customview:customview-poolingcontainer:1.1.0")
+    // Workaround for https://issuetracker.google.com/issues/227767363
+    debugApi(libs.androidx.customview)
+    debugApi(libs.androidx.customview.poolingcontainer)
 
-    // Testing
-    testImplementation("junit:junit:4.13.2")
-
-    // Curiosity testing utils
+    testImplementation(libs.junit)
     testImplementation(project(":test-compose-utils"))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.11.0")
-    testImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
-    testImplementation("org.robolectric:robolectric:4.16.1") {
-        exclude(module = "classworlds")
-        exclude(module = "commons-logging")
-        exclude(module = "httpclient")
-        exclude(module = "maven-artifact")
-        exclude(module = "maven-artifact-manager")
-        exclude(module = "maven-error-diagnostics")
-        exclude(module = "maven-model")
-        exclude(module = "maven-project")
-        exclude(module = "maven-settings")
-        exclude(module = "plexus-container-default")
-        exclude(module = "plexus-interpolation")
-        exclude(module = "plexus-utils")
-        exclude(module = "wagon-file")
-        exclude(module = "wagon-http-lightweight")
-        exclude(module = "wagon-provider-api")
-        exclude(module = "auto-service")
-    }
-
-    // Android Testing
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
-    androidTestImplementation("androidx.test.ext:junit:1.3.0")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 }
 
-tasks.withType<Sign>().configureEach {
-    onlyIf { System.getenv("CI") == "true" }
-}
+extra["robolectricConfiguration"] = "testImplementation"
+apply(from = "$rootDir/gradle/robolectric.gradle.kts")
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-                groupId = "io.github.hellocuriosity"
-                artifactId = "curiosity"
-
-                pom {
-                    name.set("Curiosity")
-                    description.set("Curiosity is a simple design system just for fun.")
-                    url.set("https://github.com/HelloCuriosity/curiosity")
-                    licenses {
-                        license {
-                            name.set("MIT Licence")
-                            url.set("https://github.com/HelloCuriosity/curiosity/blob/main/LICENSE")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set("hopeman15")
-                            name.set("Kyle Roe")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        developerConnection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        url.set("https://github.com/HelloCuriosity/curiosity")
-                    }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "MavenCentral"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
-
-                credentials {
-                    username = System.getenv("SONATYPE_USER")
-                    password = System.getenv("SONATYPE_PWD")
-                }
-            }
-        }
-
-        signing {
-            val signingKey: String? = System.getenv("SIGNING_KEY")
-            val signingPwd: String? = System.getenv("SIGNING_PWD")
-            useInMemoryPgpKeys(signingKey, signingPwd)
-            sign(publishing.publications["release"])
-        }
-    }
-}
+extra["publishingArtifactId"] = "curiosity"
+extra["publishingName"] = "Curiosity"
+extra["publishingDescription"] = "Curiosity is a simple design system just for fun."
+apply(from = "$rootDir/gradle/publishing.gradle.kts")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,97 @@
+[versions]
+# Plugins
+agp = "8.13.2"
+kotlin = "2.3.21"
+detekt = "1.23.8"
+kotlinter = "5.4.2"
+kover = "0.9.8"
+playPublisher = "3.13.0"
+
+# AndroidX
+coreKtx = "1.16.0"
+activityCompose = "1.10.1"
+composeMaterial = "1.11.0"
+composeMaterialIconsExtended = "1.7.8"
+composeUi = "1.11.0"
+customview = "1.2.0"
+customviewPoolingContainer = "1.1.0"
+navigationCompose = "2.9.8"
+
+# Android
+compileSdk = "35"
+minSdk = "23"
+targetSdk = "35"
+buildTools = "34.0.0"
+
+# Library targetSdk (curiosity, navigation)
+libraryTargetSdk = "34"
+
+# Other libs
+leakcanary = "2.14"
+ktor = "3.4.3"
+kotlinxSerialization = "1.11.0"
+modelForge = "1.5.1"
+mockk = "1.14.9"
+slf4j = "2.0.17"
+
+# Testing
+junit = "4.13.2"
+robolectric = "4.16.1"
+espresso = "3.7.0"
+androidxJunit = "1.3.0"
+
+[libraries]
+# AndroidX
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+
+# Compose
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "composeMaterial" }
+androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeMaterialIconsExtended" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeUi" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeUi" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "composeUi" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "composeUi" }
+
+# Customview workaround for compose preview (https://issuetracker.google.com/issues/227767363)
+androidx-customview = { module = "androidx.customview:customview", version.ref = "customview" }
+androidx-customview-poolingcontainer = { module = "androidx.customview:customview-poolingcontainer", version.ref = "customviewPoolingContainer" }
+
+# Navigation
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "navigationCompose" }
+
+# Leak detection
+leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
+
+# Ktor
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
+# Serialization
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+
+# Testing
+junit = { module = "junit:junit", version.ref = "junit" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+model-forge = { module = "io.github.hellocuriosity:model-forge", version.ref = "modelForge" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+play-publisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }

--- a/gradle/publishing.gradle.kts
+++ b/gradle/publishing.gradle.kts
@@ -1,0 +1,82 @@
+// Shared Maven Central publishing configuration.
+//
+// Modules apply this script after declaring the `maven-publish` and `signing`
+// plugins, and after setting:
+//   extra["publishingArtifactId"]  = "..."
+//   extra["publishingName"]        = "..."
+//   extra["publishingDescription"] = "..."
+
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+
+val artifactId = extra["publishingArtifactId"] as String
+val publicationName = extra["publishingName"] as String
+val publicationDescription = extra["publishingDescription"] as String
+
+fun PublishingExtension.configureMavenCentral() {
+    publications {
+        create<MavenPublication>("release") {
+            val component = if (plugins.hasPlugin("com.android.library")) "release" else "java"
+            from(components[component])
+            groupId = "io.github.hellocuriosity"
+            this.artifactId = artifactId
+
+            pom {
+                name.set(publicationName)
+                description.set(publicationDescription)
+                url.set("https://github.com/HelloCuriosity/curiosity")
+                licenses {
+                    license {
+                        name.set("MIT Licence")
+                        url.set("https://github.com/HelloCuriosity/curiosity/blob/main/LICENSE")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("hopeman15")
+                        name.set("Kyle Roe")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
+                    developerConnection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
+                    url.set("https://github.com/HelloCuriosity/curiosity")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "MavenCentral"
+            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
+            credentials {
+                username = System.getenv("SONATYPE_USER")
+                password = System.getenv("SONATYPE_PWD")
+            }
+        }
+    }
+}
+
+fun Project.configureSigning() {
+    extensions.configure<SigningExtension>("signing") {
+        useInMemoryPgpKeys(System.getenv("SIGNING_KEY"), System.getenv("SIGNING_PWD"))
+        sign(extensions.getByType<PublishingExtension>().publications["release"])
+    }
+}
+
+tasks.withType<Sign>().configureEach {
+    onlyIf { System.getenv("CI") == "true" }
+}
+
+if (plugins.hasPlugin("com.android.library")) {
+    afterEvaluate {
+        extensions.configure<PublishingExtension>("publishing") { configureMavenCentral() }
+        configureSigning()
+    }
+} else {
+    extensions.configure<PublishingExtension>("publishing") { configureMavenCentral() }
+    configureSigning()
+}

--- a/gradle/robolectric.gradle.kts
+++ b/gradle/robolectric.gradle.kts
@@ -1,0 +1,34 @@
+// Adds Robolectric with the project's standard exclusion list.
+//
+// Modules apply this script after setting:
+//   extra["robolectricConfiguration"] = "testImplementation" // or "implementation"
+
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
+val configuration = extra["robolectricConfiguration"] as String
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+val excludedModules = listOf(
+    "classworlds",
+    "commons-logging",
+    "httpclient",
+    "maven-artifact",
+    "maven-artifact-manager",
+    "maven-error-diagnostics",
+    "maven-model",
+    "maven-project",
+    "maven-settings",
+    "plexus-container-default",
+    "plexus-interpolation",
+    "plexus-utils",
+    "wagon-file",
+    "wagon-http-lightweight",
+    "wagon-provider-api",
+    "auto-service",
+)
+
+dependencies {
+    configuration(libs.findLibrary("robolectric").get()) {
+        excludedModules.forEach { exclude(module = it) }
+    }
+}

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -1,172 +1,45 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
 
-    // Publishing
-    id("maven-publish")
+    `maven-publish`
     signing
 }
 
 android {
     namespace = "io.github.hellocuriosity.compose.navigation"
-    compileSdk = 35
-    buildToolsVersion = "34.0.0"
-
-    defaultConfig {
-        minSdk = 23
-        targetSdk = 34
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    buildFeatures {
-        compose = true
-    }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-            isReturnDefaultValues = true
-        }
-    }
 }
 
 dependencies {
-    // Android
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation(libs.androidx.core.ktx)
 
-    // Compose
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.compose.material:material:1.11.0")
-    implementation("androidx.navigation:navigation-compose:2.9.8")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.11.0")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.11.0")
-    implementation("androidx.compose.ui:ui:1.11.0")
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
-    // It is a known bug: https://issuetracker.google.com/issues/227767363
-    //
-    // Google is currently working on a fix but there is already a workaround:
-    // add these dependencies to every module where you use the Compose preview:
-    debugApi("androidx.customview:customview:1.2.0")
-    debugApi("androidx.customview:customview-poolingcontainer:1.1.0")
+    // Workaround for https://issuetracker.google.com/issues/227767363
+    debugApi(libs.androidx.customview)
+    debugApi(libs.androidx.customview.poolingcontainer)
 
-    // Testing
-    testImplementation("junit:junit:4.13.2")
-
-    // Curiosity testing utils
+    testImplementation(libs.junit)
     testImplementation(project(":test-compose-utils"))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.androidx.navigation.testing)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-    // Compose
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.11.0")
-    testImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
-    testImplementation("androidx.navigation:navigation-testing:2.9.8")
-
-    testImplementation("org.robolectric:robolectric:4.16.1") {
-        exclude(module = "classworlds")
-        exclude(module = "commons-logging")
-        exclude(module = "httpclient")
-        exclude(module = "maven-artifact")
-        exclude(module = "maven-artifact-manager")
-        exclude(module = "maven-error-diagnostics")
-        exclude(module = "maven-model")
-        exclude(module = "maven-project")
-        exclude(module = "maven-settings")
-        exclude(module = "plexus-container-default")
-        exclude(module = "plexus-interpolation")
-        exclude(module = "plexus-utils")
-        exclude(module = "wagon-file")
-        exclude(module = "wagon-http-lightweight")
-        exclude(module = "wagon-provider-api")
-        exclude(module = "auto-service")
-    }
-
-    // Android Testing
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
-    androidTestImplementation("androidx.test.ext:junit:1.3.0")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 }
 
-tasks.withType<Sign>().configureEach {
-    onlyIf { System.getenv("CI") == "true" }
-}
+extra["robolectricConfiguration"] = "testImplementation"
+apply(from = "$rootDir/gradle/robolectric.gradle.kts")
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-                groupId = "io.github.hellocuriosity"
-                artifactId = "navigation"
-
-                pom {
-                    name.set("Navigation")
-                    description.set("Compose navigation components")
-                    url.set("https://github.com/HelloCuriosity/curiosity")
-                    licenses {
-                        license {
-                            name.set("MIT Licence")
-                            url.set("https://github.com/HelloCuriosity/curiosity/blob/main/LICENSE")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set("hopeman15")
-                            name.set("Kyle Roe")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        developerConnection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        url.set("https://github.com/HelloCuriosity/curiosity")
-                    }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "MavenCentral"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
-
-                credentials {
-                    username = System.getenv("SONATYPE_USER")
-                    password = System.getenv("SONATYPE_PWD")
-                }
-            }
-        }
-
-        signing {
-            val signingKey: String? = System.getenv("SIGNING_KEY")
-            val signingPwd: String? = System.getenv("SIGNING_PWD")
-            useInMemoryPgpKeys(signingKey, signingPwd)
-            sign(publishing.publications["release"])
-        }
-    }
-}
+extra["publishingArtifactId"] = "navigation"
+extra["publishingName"] = "Navigation"
+extra["publishingDescription"] = "Compose navigation components"
+apply(from = "$rootDir/gradle/publishing.gradle.kts")

--- a/settings/build.gradle.kts
+++ b/settings/build.gradle.kts
@@ -1,171 +1,51 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
 
-    // Publishing
-    id("maven-publish")
+    `maven-publish`
     signing
 }
 
 android {
     namespace = "io.github.hellocuriosity.compose.settings"
-    compileSdk = 35
 
     defaultConfig {
-        minSdk = 23
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    buildFeatures {
-        compose = true
-    }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-            isReturnDefaultValues = true
-        }
     }
 }
 
 dependencies {
-    // Android
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation(libs.androidx.core.ktx)
 
-    // Compose
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.compose.material:material:1.11.0")
-    implementation("androidx.navigation:navigation-compose:2.9.8")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.11.0")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.11.0")
-    implementation("androidx.compose.ui:ui:1.11.0")
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
-    // Curiosity
     implementation(project(":curiosity"))
 
-    // It is a known bug: https://issuetracker.google.com/issues/227767363
-    //
-    // Google is currently working on a fix but there is already a workaround:
-    // add these dependencies to every module where you use the Compose preview:
-    debugApi("androidx.customview:customview:1.2.0")
-    debugApi("androidx.customview:customview-poolingcontainer:1.1.0")
+    // Workaround for https://issuetracker.google.com/issues/227767363
+    debugApi(libs.androidx.customview)
+    debugApi(libs.androidx.customview.poolingcontainer)
 
-    // Testing
-    testImplementation("junit:junit:4.13.2")
-
-    // Curiosity testing utils
+    testImplementation(libs.junit)
     testImplementation(project(":test-compose-utils"))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.11.0")
-    testImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
-    testImplementation("org.robolectric:robolectric:4.16.1") {
-        exclude(module = "classworlds")
-        exclude(module = "commons-logging")
-        exclude(module = "httpclient")
-        exclude(module = "maven-artifact")
-        exclude(module = "maven-artifact-manager")
-        exclude(module = "maven-error-diagnostics")
-        exclude(module = "maven-model")
-        exclude(module = "maven-project")
-        exclude(module = "maven-settings")
-        exclude(module = "plexus-container-default")
-        exclude(module = "plexus-interpolation")
-        exclude(module = "plexus-utils")
-        exclude(module = "wagon-file")
-        exclude(module = "wagon-http-lightweight")
-        exclude(module = "wagon-provider-api")
-        exclude(module = "auto-service")
-    }
-
-    // Android Testing
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
-    androidTestImplementation("androidx.test.ext:junit:1.3.0")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.11.0")
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 }
 
-tasks.withType<Sign>().configureEach {
-    onlyIf { System.getenv("CI") == "true" }
-}
+extra["robolectricConfiguration"] = "testImplementation"
+apply(from = "$rootDir/gradle/robolectric.gradle.kts")
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-                groupId = "io.github.hellocuriosity"
-                artifactId = "settings"
-
-                pom {
-                    name.set("Settings")
-                    description.set("Settings is a collection of setting specific UI components to speed up building settings screens.")
-                    url.set("https://github.com/HelloCuriosity/curiosity")
-                    licenses {
-                        license {
-                            name.set("MIT Licence")
-                            url.set("https://github.com/HelloCuriosity/curiosity/blob/main/LICENSE")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set("hopeman15")
-                            name.set("Kyle Roe")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        developerConnection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        url.set("https://github.com/HelloCuriosity/curiosity")
-                    }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "MavenCentral"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
-
-                credentials {
-                    username = System.getenv("SONATYPE_USER")
-                    password = System.getenv("SONATYPE_PWD")
-                }
-            }
-        }
-
-        signing {
-            val signingKey: String? = System.getenv("SIGNING_KEY")
-            val signingPwd: String? = System.getenv("SIGNING_PWD")
-            useInMemoryPgpKeys(signingKey, signingPwd)
-            sign(publishing.publications["release"])
-        }
-    }
-}
+extra["publishingArtifactId"] = "settings"
+extra["publishingName"] = "Settings"
+extra["publishingDescription"] =
+    "Settings is a collection of setting specific UI components to speed up building settings screens."
+apply(from = "$rootDir/gradle/publishing.gradle.kts")

--- a/slack-feedback/build.gradle.kts
+++ b/slack-feedback/build.gradle.kts
@@ -1,99 +1,35 @@
 plugins {
-    id("java-library")
+    `java-library`
     id("org.jetbrains.kotlin.jvm")
-    kotlin("plugin.serialization") version "2.3.21"
+    id("org.jetbrains.kotlin.plugin.serialization")
 
-    // Publishing
-    id("maven-publish")
+    `maven-publish`
     signing
 }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
-}
-
-dependencies {
-    // Ktor
-    implementation("io.ktor:ktor-client-content-negotiation:3.4.3")
-    implementation("io.ktor:ktor-client-core:3.4.3")
-    implementation("io.ktor:ktor-client-okhttp:3.4.3")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.4.3")
-
-    // Serialization
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
-
-    // Testing
-    testImplementation("junit:junit:4.13.2")
-
-    // Model forge
-    testImplementation("io.github.hellocuriosity:model-forge:1.5.1")
-
-    // Mockk
-    testImplementation("io.mockk:mockk:1.14.9")
-
-    // Ktor
-    testImplementation("io.ktor:ktor-client-mock:3.4.3")
-    testImplementation("org.slf4j:slf4j-simple:2.0.17")
-}
-
-java {
     withSourcesJar()
     withJavadocJar()
 }
 
-tasks.withType<Sign>().configureEach {
-    onlyIf { System.getenv("CI") == "true" }
+dependencies {
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.serialization.kotlinx.json)
+
+    implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.model.forge)
+    testImplementation(libs.mockk)
+    testImplementation(libs.ktor.client.mock)
+    testImplementation(libs.slf4j.simple)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("release") {
-            from(components["java"])
-            groupId = "io.github.hellocuriosity"
-            artifactId = "slack-feedback"
-
-            pom {
-                name.set("Slack Feedback")
-                description.set("Slack Feedback is an easy way to collect feedback, and have it posted to a slack channel.")
-                url.set("https://github.com/HelloCuriosity/curiosity")
-                licenses {
-                    license {
-                        name.set("MIT Licence")
-                        url.set("https://github.com/HelloCuriosity/curiosity/blob/main/LICENSE")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("hopeman15")
-                        name.set("Kyle Roe")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                    developerConnection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                    url.set("https://github.com/HelloCuriosity/curiosity")
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "MavenCentral"
-            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
-
-            credentials {
-                username = System.getenv("SONATYPE_USER")
-                password = System.getenv("SONATYPE_PWD")
-            }
-        }
-    }
-
-    signing {
-        val signingKey: String? = System.getenv("SIGNING_KEY")
-        val signingPwd: String? = System.getenv("SIGNING_PWD")
-        useInMemoryPgpKeys(signingKey, signingPwd)
-        sign(publishing.publications["release"])
-    }
-}
+extra["publishingArtifactId"] = "slack-feedback"
+extra["publishingName"] = "Slack Feedback"
+extra["publishingDescription"] = "Slack Feedback is an easy way to collect feedback, and have it posted to a slack channel."
+apply(from = "$rootDir/gradle/publishing.gradle.kts")

--- a/test-compose-utils/build.gradle.kts
+++ b/test-compose-utils/build.gradle.kts
@@ -1,141 +1,33 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
 
-    // Publishing
-    id("maven-publish")
+    `maven-publish`
     signing
 }
 
 android {
     namespace = "io.github.hellocuriosity.test.compose"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 23
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    buildFeatures {
-        compose = true
-    }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
 }
+
+// This module hosts test utilities; it has no tests of its own.
+tasks.withType<Test>().configureEach { failOnNoDiscoveredTests = false }
 
 dependencies {
-    // Android
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation(libs.androidx.core.ktx)
 
-    // Compose
-    implementation("androidx.navigation:navigation-compose:2.9.8")
-    implementation("androidx.navigation:navigation-testing:2.9.8")
-    implementation("androidx.compose.ui:ui-test-junit4:1.11.0")
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.navigation.testing)
+    implementation(libs.androidx.compose.ui.test.junit4)
 
-    // jUnit
-    implementation("junit:junit:4.13.2")
-
-    // Robolectric
-    implementation("org.robolectric:robolectric:4.16.1") {
-        exclude(module = "classworlds")
-        exclude(module = "commons-logging")
-        exclude(module = "httpclient")
-        exclude(module = "maven-artifact")
-        exclude(module = "maven-artifact-manager")
-        exclude(module = "maven-error-diagnostics")
-        exclude(module = "maven-model")
-        exclude(module = "maven-project")
-        exclude(module = "maven-settings")
-        exclude(module = "plexus-container-default")
-        exclude(module = "plexus-interpolation")
-        exclude(module = "plexus-utils")
-        exclude(module = "wagon-file")
-        exclude(module = "wagon-http-lightweight")
-        exclude(module = "wagon-provider-api")
-        exclude(module = "auto-service")
-    }
+    implementation(libs.junit)
 }
 
-tasks.withType<Sign>().configureEach {
-    onlyIf { System.getenv("CI") == "true" }
-}
+extra["robolectricConfiguration"] = "implementation"
+apply(from = "$rootDir/gradle/robolectric.gradle.kts")
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-                groupId = "io.github.hellocuriosity"
-                artifactId = "test-utils"
-
-                pom {
-                    name.set("Test-Utils")
-                    description.set("Test-Utils is a collection of test utilities to help test compose UIs.")
-                    url.set("https://github.com/HelloCuriosity/curiosity")
-                    licenses {
-                        license {
-                            name.set("MIT Licence")
-                            url.set("https://github.com/HelloCuriosity/curiosity/blob/main/LICENSE")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set("hopeman15")
-                            name.set("Kyle Roe")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        developerConnection.set("scm:git:https://github.com/HelloCuriosity/curiosity.git")
-                        url.set("https://github.com/HelloCuriosity/curiosity")
-                    }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "MavenCentral"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
-
-                credentials {
-                    username = System.getenv("SONATYPE_USER")
-                    password = System.getenv("SONATYPE_PWD")
-                }
-            }
-        }
-
-        signing {
-            val signingKey: String? = System.getenv("SIGNING_KEY")
-            val signingPwd: String? = System.getenv("SIGNING_PWD")
-            useInMemoryPgpKeys(signingKey, signingPwd)
-            sign(publishing.publications["release"])
-        }
-    }
-}
+extra["publishingArtifactId"] = "test-utils"
+extra["publishingName"] = "Test-Utils"
+extra["publishingDescription"] = "Test-Utils is a collection of test utilities to help test compose UIs."
+apply(from = "$rootDir/gradle/publishing.gradle.kts")


### PR DESCRIPTION
## Description

Cleans up redundancy across the per-module gradle files. Each module previously
duplicated Android library setup, the Maven Central publishing block, and the
Robolectric exclusion list. This consolidates them into shared locations:

- `gradle/libs.versions.toml` — version catalog for all plugin and dependency versions.
- Common Android library/application config (compileSdk, minSdk, JVM 17, compose,
  testOptions) moved to `subprojects` blocks in the root build script, applied
  via `plugins.withId(...)`.
- `gradle/publishing.gradle.kts` — Maven Central publishing, parameterized by
  artifactId/name/description and consumed via `apply(from = ...)`.
- `gradle/robolectric.gradle.kts` — Robolectric dependency with the standard
  exclusion list, consumed via `apply(from = ...)`.

Net: -529 lines across module build files. Behavior preserved (verified via
`make all` and `publishToMavenLocal` with identical POMs).

Closes #113 
Closes #114

## UI

Not applicable.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied