### PR TITLE
chore: bump compile/target SDK to 37 and source from catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "com.hello.curiosity.design"
-        targetSdk = 35
+        targetSdk = libs.versions.targetSdk.get().toInt()
 
         versionCode = System.getenv("GITHUB_RUN_NUMBER")?.toInt() ?: 1
         versionName = System.getenv("VERSION") ?: "local"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ subprojects {
         extensions.configure<LibraryExtension>("android") {
             configureAndroidCommon()
             defaultConfig {
-                targetSdk = libs.versions.libraryTargetSdk.get().toInt()
+                targetSdk = libs.versions.targetSdk.get().toInt()
             }
             buildTypes {
                 release {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,9 +45,9 @@ allprojects {
 }
 
 fun CommonExtension<*, *, *, *, *, *>.configureAndroidCommon() {
-    compileSdk = 35
+    compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
-        minSdk = 23
+        minSdk = libs.versions.minSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -76,7 +76,7 @@ subprojects {
         extensions.configure<LibraryExtension>("android") {
             configureAndroidCommon()
             defaultConfig {
-                targetSdk = 35
+                targetSdk = libs.versions.libraryTargetSdk.get().toInt()
             }
             buildTypes {
                 release {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,9 +23,6 @@ minSdk = "23"
 targetSdk = "37"
 buildTools = "34.0.0"
 
-# Library targetSdk (curiosity, navigation)
-libraryTargetSdk = "37"
-
 # Other libs
 leakcanary = "2.14"
 ktor = "3.4.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,13 +18,13 @@ customviewPoolingContainer = "1.1.0"
 navigationCompose = "2.9.8"
 
 # Android
-compileSdk = "35"
+compileSdk = "37"
 minSdk = "23"
-targetSdk = "35"
+targetSdk = "37"
 buildTools = "34.0.0"
 
 # Library targetSdk (curiosity, navigation)
-libraryTargetSdk = "34"
+libraryTargetSdk = "37"
 
 # Other libs
 leakcanary = "2.14"


### PR DESCRIPTION
## Description

Bumps `compileSdk` and `targetSdk` from 35 to 37 (and `libraryTargetSdk` from an unwired 34 to 37 — libraries were silently using 35 before).

The SDK versions are now sourced from `gradle/libs.versions.toml` instead of being hardcoded in the build files. Future bumps only need a single change in the catalog.

- `gradle/libs.versions.toml`: bump `compileSdk`, `targetSdk`, `libraryTargetSdk` to 37
- `build.gradle.kts`: read `compileSdk`, `minSdk`, `libraryTargetSdk` from catalog
- `app/build.gradle.kts`: read `targetSdk` from catalog

## UI

N/A — build configuration only.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied